### PR TITLE
Adding shadow enpoint to setting desired state, and get reported state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,6 @@ package-template:
 deploy-template:
 	aws cloudformation deploy \
 	--template-file template-output.yaml \
-	--stack-name iot-cvm-stack \
+	--stack-name followme-deviceinfo \
 	--capabilities CAPABILITY_NAMED_IAM \
 	--region $(deploy_region)

--- a/lambda/config.js
+++ b/lambda/config.js
@@ -15,6 +15,8 @@ const config = {
       }
     ]
   }`,
+  IOT_SHADOW_ALLOWED_KEYS: { "room": true },
+  IOT_DATA_ENDPOINT: 'a3vzqpudtrlbrd-ats.iot.us-west-2.amazonaws.com',
   ROOT_CA_URL: 'https://www.amazontrust.com/repository/AmazonRootCA1.pem'
 };
 

--- a/template.yaml
+++ b/template.yaml
@@ -10,11 +10,9 @@ Outputs:
   LambdaArn:
     Description: "Lambda Arn"
     Value: !GetAtt LambdaRole.Arn
-  CVMIoTApi:
-    Description: "API Gateway endpoint URL for Prod stage for API Gateway"
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/getcert?serialNumber=ascas&deviceToken=zxcz"
-    Export:
-      Name: !Join [ ":", [ !Ref "AWS::StackName", CVMIoTApi ] ]        
+  Api:
+    Description: "API Gateway endpoint URL for Prod stage"
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
 Resources:
   CVMIoTResource:
     Type: 'AWS::Serverless::Function'
@@ -36,6 +34,11 @@ Resources:
             Properties:
                 Path: /getcert
                 Method: GET
+        ShadowIoTApi:
+            Type: Api
+            Properties:
+                Path: /shadow
+                Method: ANY
   DeviceInfoDynamoDBTable:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -105,4 +108,6 @@ Resources:
             - iot:CreateKeysAndCertificate
             - iot:UpdateCertificate
             - iot:DeleteCertificate
+            - iot:GetThingShadow
+            - iot:UpdateThingShadow
             Resource: "*"


### PR DESCRIPTION
*Description of changes:*

New `/shadow` endpoint supports two methods:
* GET: Retrieve the latest reported shadow state.
* PUT: Request a desired to changed to the shadow based on payload body.

Configuration specifies the `iot-data` endpoint and `allowed-keys` to be get/set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
